### PR TITLE
[Shadow Realms] Wrapped functions only throw calling realms' TypeError

### DIFF
--- a/JSTests/ChangeLog
+++ b/JSTests/ChangeLog
@@ -1,3 +1,18 @@
+2021-12-15  Joseph Griego  <jgriego@igalia.com>
+
+        [Shadow Realms] Wrapped functions must only throw TypeError from calling realm
+        https://bugs.webkit.org/show_bug.cgi?id=234357
+
+        Test the cases when the exception would be thrown by a function
+        originating from both the shadow realm and the incubating realm.
+
+        Reviewed by NOBODY (OOPS!).
+
+        * stress/shadow-realm-evaluate.js:
+        (shouldBe):
+        (let.f.realm.evaluate):
+        (shouldBe.f):
+
 2021-12-13  Yusuke Suzuki  <ysuzuki@apple.com>
 
         [JSC] Update Intl tests based on ICU 69~

--- a/Source/JavaScriptCore/ChangeLog
+++ b/Source/JavaScriptCore/ChangeLog
@@ -1,3 +1,25 @@
+2021-12-15  Joseph Griego  <jgriego@igalia.com>
+
+        [Shadow Realms] Wrapped functions must only throw TypeError from calling realm
+        https://bugs.webkit.org/show_bug.cgi?id=234357
+
+        Reviewed by NOBODY (OOPS!).
+
+        This wrapping logic already exists for ShadowRealm.prototype.evaluate
+        but not for calls to wrapped functions. at present, this requires some
+        awkward manouvering to actually throw a typeerror from the shadow realm,
+        since the wrapper code always runs in the incubating realm.
+
+        Hopefully we can make this less messy soon by replacing this
+        implementation with one more integrated with the runtime.
+
+        This case wasn't covered by existing JSC or test262 tests; added
+        coverage both upstream in t262 and in this patch.
+
+        * builtins/ShadowRealmPrototype.js:
+        (wrapped):
+        (globalPrivate.wrap):
+
 2021-12-14  Jean-Yves Avenard  <jya@apple.com>
 
         Rename SharedBuffer classes.

--- a/Source/JavaScriptCore/builtins/ShadowRealmPrototype.js
+++ b/Source/JavaScriptCore/builtins/ShadowRealmPrototype.js
@@ -42,7 +42,18 @@ function wrap(fromShadowRealm, shadowRealm, target)
                 // calling the wrapped function
                 @putByValDirect(wrappedArgs, index, @wrap(!fromShadowRealm, shadowRealm, arguments[index]));
 
-            var result = target.@apply(@undefined, wrappedArgs);
+            try {
+                var result = target.@apply(@undefined, wrappedArgs);
+            } catch (e) {
+                const msg = "wrapped function threw: " + e.toString();
+                if (fromShadowRealm)
+                    @throwTypeError(msg);
+                else {
+                    const mkTypeError = @evalInRealm(shadowRealm, "(msg) => new TypeError(msg)");
+                    const err = mkTypeError.@apply(msg);
+                    throw err;
+                }
+            }
             return @wrap(fromShadowRealm, shadowRealm, result);
         };
         delete wrapped['name'];


### PR DESCRIPTION
This wrapping logic already exists for `ShadowRealm.prototype.evaluate` but not
for calls to wrapped functions. At present, this requires some awkward
manouvering to actually throw a TypeError from the shadow realm, since the
wrapper code always runs in the incubating realm.

Fixes new tests added to cover this case in test262